### PR TITLE
docs: tensor ops return functions, not tensors

### DIFF
--- a/minitorch/tensor_ops.py
+++ b/minitorch/tensor_ops.py
@@ -71,7 +71,8 @@ def map(fn):
                should broadcast with `a`
 
     Returns:
-        :class:`TensorData` : new tensor data
+        function: A function that takes a tensor, applies `fn` to each cell,
+        and returns the resulting tensor.
     """
 
     f = tensor_map(fn)
@@ -160,7 +161,8 @@ def zip(fn):
         b (:class:`TensorData`): tensor to zip over
 
     Returns:
-        :class:`TensorData` : new tensor data
+        function: A function that takes two tensors, applies `fn` to each pair
+        of cells, and returns the resulting tensor.
     """
 
     f = tensor_zip(fn)
@@ -225,7 +227,9 @@ def reduce(fn, start=0.0):
         dim (int): int of dim to reduce
 
     Returns:
-        :class:`TensorData` : new tensor
+        function: A function that takes a tensor, applies `fn` to all cells
+        along a particular axis (or all cells if `dim` is not specified), and
+        returns the resulting tensor.
     """
     f = tensor_reduce(fn)
 


### PR DESCRIPTION
The docs as currently written are a bit misleading as they suggest that these higher-order functions returns `Tensor`s directly, when in fact they return functions that return tensors.