### PR TITLE
Update tensor_ops.py docs

### DIFF
--- a/minitorch/tensor_ops.py
+++ b/minitorch/tensor_ops.py
@@ -71,7 +71,8 @@ def map(fn):
                should broadcast with `a`
 
     Returns:
-        :class:`TensorData` : new tensor data
+        function: A function that takes a tensor, applies `fn` to each cell,
+        and returns the resulting tensor.
     """
 
     f = tensor_map(fn)
@@ -160,7 +161,8 @@ def zip(fn):
         b (:class:`TensorData`): tensor to zip over
 
     Returns:
-        :class:`TensorData` : new tensor data
+        function: A function that takes two tensors, applies `fn` to each pair
+        of cells, and returns the resulting tensor.
     """
 
     f = tensor_zip(fn)
@@ -225,7 +227,9 @@ def reduce(fn, start=0.0):
         dim (int): int of dim to reduce
 
     Returns:
-        :class:`TensorData` : new tensor
+        function: A function that takes a tensor, applies `fn` to all cells
+        along a particular axis (or all cells if `dim` is not specified), and
+        returns the resulting tensor.
     """
     f = tensor_reduce(fn)
 

--- a/minitorch/tensor_ops.py
+++ b/minitorch/tensor_ops.py
@@ -6,6 +6,8 @@ from .tensor_data import (
     shape_broadcast,
     MAX_DIMS,
 )
+from minitorch import Tensor
+from typing import Callable
 
 
 def tensor_map(fn):
@@ -44,7 +46,7 @@ def tensor_map(fn):
     return _map
 
 
-def map(fn):
+def map(fn: Callable[[float], float]) -> Callable[[Tensor], Tensor]:
     """
     Higher-order tensor map function ::
 
@@ -135,7 +137,7 @@ def tensor_zip(fn):
     return _zip
 
 
-def zip(fn):
+def zip(fn: Callable[[float, float], float]) -> Callable[[Tensor, Tensor], Tensor]:
     """
     Higher-order tensor zip function ::
 
@@ -206,7 +208,7 @@ def tensor_reduce(fn):
     return _reduce
 
 
-def reduce(fn, start=0.0):
+def reduce(fn: Callable[[float, float], float], start: float = 0.0) -> Callable[[Tensor, float], Tensor]:
     """
     Higher-order tensor reduce function. ::
 


### PR DESCRIPTION
Problem:

The docs as currently written are a bit misleading as they suggest that
these higher-order functions returns `Tensor`s directly, when in fact
they return functions that return `Tensor`s.

Solution:

- Update function docs to reflect that these functions return functions
- Add type annotations for higher-order functions to reinforce the above (happy to remove this we don't want to piece-meal introduce types to minitorch)